### PR TITLE
Removed unnecessary splice to copy array on line 72

### DIFF
--- a/lib/solutions.js
+++ b/lib/solutions.js
@@ -48,8 +48,6 @@ function merge (left, right) {
 
 
 function radixSort (unsortedArray) {
-  // copy array
-  var array = unsortedArray.slice();
   // define places such that the 4 in 1234 is place 0 and 3 in 1234 is place 1
   var placeToSortBy = 0;
 

--- a/lib/solutions.js
+++ b/lib/solutions.js
@@ -47,7 +47,7 @@ function merge (left, right) {
 }
 
 
-function radixSort (unsortedArray) {
+function radixSort (array) {
   // define places such that the 4 in 1234 is place 0 and 3 in 1234 is place 1
   var placeToSortBy = 0;
 


### PR DESCRIPTION
The array splice appears unnecessary. Assigning to an array reference within a function will not overwrite the array outside of the function, so the splice is unnecessary. JS passes a "pointer copy" to the callee.
